### PR TITLE
feat: remove the unnecessary verbose makefiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,140 +6,29 @@ endef
 # Store the branch name in a variable
 GIT_BRANCH := $(call get_branch)
 
-# weathercore
-build-weathercore-amd64:
-	docker build -f apps/weathercore/Dockerfile -t syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-
-build-weathercore-aarch64:
-	docker build -f apps/weathercore/Dockerfile -t syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
+create-builder:
+	docker buildx create --name mybuilder --use --bootstrap
 
 build-weathercore:
-	docker build -f apps/weathercore/Dockerfile -t syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-	docker build -f apps/weathercore/Dockerfile -t syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
-
-push-weathercore-amd64:
-	docker push syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-amd64
-
-push-weathercore-aarch64:
-	docker push syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-aarch64
-
-push-weathercore:
-	docker push syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-amd64
-	docker push syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-aarch64
-
-build-manifest-weathercore:
-	docker manifest create \
-		syahshiimi/ouroboros-weathercore:${GIT_BRANCH} \
-		--amend syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-amd64 \
-		--amend syahshiimi/ouroboros-weathercore:${GIT_BRANCH}-aarch64
-
-inspect-manifest-weathercore:
-	docker manifest inspect syahshiimi/ouroboros-weathercore:${GIT_BRANCH}
-
-push-manifest-weathercore:
-	docker manifest push syahshiimi/ouroboros-weathercore:${GIT_BRANCH}
-
-# weathercore-migrations
-build-weathercore-migrations-amd64:
-	docker build -f packages/weathercore-database/Dockerfile -t syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-
-build-weathercore-migrations-aarch64:
-	docker build -f packages/weathercore-database/Dockerfile -t syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-f apps/weathercore/Dockerfile \
+		-t syahshiimi/ouroboros-weathercore:${GIT_BRANCH} \
+		--push .
 
 build-weathercore-migrations:
-	docker build -f packages/weathercore-database/Dockerfile -t syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-	docker build -f packages/weathercore-database/Dockerfile -t syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
-
-push-weathercore-migrations-amd64:
-	docker push syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-amd64
-
-push-weathercore-migrations-aarch64:
-	docker push syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-aarch64
-
-push-weathercore-migrations:
-	docker push syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-amd64
-	docker push syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-aarch64
-
-build-manifest-weathercore-migrations:
-	docker manifest create \
-		syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH} \
-		--amend syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-amd64 \
-		--amend syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}-aarch64
-
-inspect-manifest-weathercore-migrations:
-	docker manifest inspect syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}
-
-push-manifest-weathercore-migrations:
-	docker manifest push syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH}
-
-# feeder-api
-build-feeder-api-amd64:
-	docker build -f apps/feeder/Dockerfile -t syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-
-build-feeder-api-aarch64:
-	docker build -f apps/feeder/Dockerfile -t syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-f packages/weathercore-database/Dockerfile \
+		-t syahshiimi/ouroboros-weathercore-migrations:${GIT_BRANCH} \
+		--push .
 
 build-feeder-api:
-	docker build -f apps/feeder/Dockerfile -t syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-	docker build -f apps/feeder/Dockerfile -t syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
-
-push-feeder-api-amd64:
-	docker push syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-amd64
-
-push-feeder-api-aarch64:
-	docker push syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-aarch64
-
-push-feeder-api:
-	docker push syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-amd64
-	docker push syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-aarch64
-	
-build-manifest-feeder-api:
-	docker manifest create \
-		syahshiimi/ouroboros-feeder-api:${GIT_BRANCH} \
-		--amend syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-amd64 \
-		--amend syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}-aarch64
-
-inspect-manifest-feeder-api:
-	docker manifest inspect syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}
-
-push-manifest-feeder-api:
-	docker manifest push syahshiimi/ouroboros-feeder-api:${GIT_BRANCH}
-
-# feeder-worker
-build-feeder-worker:
-	docker build -f apps/feeder-worker/Dockerfile -t syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH} .
-
-push-feeder-worker:
-	docker push syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}
-
-build-feeder-worker-amd64:
-	docker build -f apps/feeder-worker/Dockerfile -t syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-
-build-feeder-worker-aarch64:
-	docker build -f apps/feeder-worker/Dockerfile -t syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-f apps/feeder/Dockerfile \
+		-t syahshiimi/ouroboros-feeder-api:${GIT_BRANCH} \
+		--push .
 
 build-feeder-worker:
-	docker build -f apps/feeder-worker/Dockerfile -t syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-amd64 --platform linux/amd64 .
-	docker build -f apps/feeder-worker/Dockerfile -t syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-aarch64 --platform linux/arm64 .
-
-push-feeder-worker-amd64:
-	docker push syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-amd64
-
-push-feeder-worker-aarch64:
-	docker push syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-aarch64
-
-push-feeder-worker:
-	docker push syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-amd64
-	docker push syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-aarch64
-	
-build-manifest-feeder-worker:
-	docker manifest create \
-		syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH} \
-		--amend syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-amd64 \
-		--amend syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}-aarch64
-
-inspect-manifest-feeder-worker:
-	docker manifest inspect syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}
-
-push-manifest-feeder-worker:
-	docker manifest push syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH}
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-f apps/feeder-worker/Dockerfile \
+		-t syahshiimi/ouroboros-feeder-worker:${GIT_BRANCH} \
+		--push .


### PR DESCRIPTION
We should use docker buildx to build and push to docker hub registry. This makes the makefile a lot cleaner and we can build multi-arch images from any desktop environment.